### PR TITLE
Beocreate service call fixes

### DIFF
--- a/beocreate/beo-extensions/tidal/index.js
+++ b/beocreate/beo-extensions/tidal/index.js
@@ -125,22 +125,22 @@ var fs = require("fs");
 	
 	function settidalStatus(enabled, callback) {
 		if (enabled) {
-			exec("systemctl start --now tidal.service").on('exit', function(code) {
+			exec("systemctl enable --now tidal.service").on('exit', function(code) {
 				if (code == 0) {
 					settings.tidalEnabled = true;
-					if (debug) console.log("Roon enabled.");
+					if (debug) console.log("TIDAL Connect enabled.");
 					callback(true);
 				} else {
-					roonEnabled = false;
+					settings.tidalEnabled = false;
 					callback(false, true);
 				}
 			});
 		} else {
-			exec("systemctl stop --now tidal.service").on('exit', function(code) {
+			exec("systemctl disable --now tidal.service").on('exit', function(code) {
 				settings.tidalEnabled = false;
 				if (code == 0) {
 					callback(false);
-					if (debug) console.log("Roon disabled.");
+					if (debug) console.log("TIDAL Connect disabled.");
 				} else {
 					callback(false, true);
 				}


### PR DESCRIPTION
Beocreate should use `systemctl enable|disable --now` to control the systemd service, not `start|stop` (for which the `--now` flag has no meaning), this PR fixes that.
In addition, a couple of typos/leftovers that made reference to Roon have been fixed.