### PR TITLE
Running audiocontrol2 in foreground not needed

### DIFF
--- a/work-in-progress/audiocontrol2/README.md
+++ b/work-in-progress/audiocontrol2/README.md
@@ -12,10 +12,10 @@ The result is that, if you start this service as background job (e.g. systemctl 
 
 * Installation
 
-1. You can either run the ./install.sh script or create the symbolic link manually.
+You can either run the ./install.sh script or add the following modifications manually
 
    ```
-   # create symbolic link to add TidalController to AudioControl2 daemon
+1. Create symbolic link to add TidalController to AudioControl2 daemon
    ln -s ${PWD}/tidalcontrol.py /opt/audiocontrol2/ac2/players/tidalcontrol.py
    ```
 2. go and edit the file and initialize the player
@@ -60,11 +60,7 @@ The result is that, if you start this service as background job (e.g. systemctl 
 5. Testing
    ```
    # Stop AudioControl2 Daemon
-   systemctl stop audiocontrol2
-
-   # Start AudioControl2 in the foreground 
-   # (NOTE due to threading bug this is needed)
-   python3 /opt/audiocontrol2/audiocontrol2.py
+   systemctl restart audiocontrol2
    ```
 
 6. Done!!!... Now open your HifiBerryOS webpage and start a song... you should see track metadata in the player. (controls from WEBUI still needs to be implemted. Controls work via Phone.)
@@ -74,6 +70,3 @@ https://github.com/hifiberry/audiocontrol2/blob/master/doc/api.md
 
 ** NOTE TO SELF: I will make a daemon which will scrape and keep track of state, independendly from the AudioController (this because Threading doesnt seem to play nicely and scraping from docker using TMUX is too slow). The daemon will scrape state in seperate thread and then update ENV vars that can be accessed globally. 
 The audiocontrol2 will simply only read the ENV vars.
-
-
-

--- a/work-in-progress/audiocontrol2/install.sh
+++ b/work-in-progress/audiocontrol2/install.sh
@@ -1,12 +1,17 @@
 #!/bin/bash
 
+AC_CONTROL_FILE="/opt/audiocontrol2/audiocontrol2.py"
 DST_PLAYER_FILE=/opt/audiocontrol2/ac2/players/tidalcontrol.py
 
-rm ${DST_PLAYER_FILE}
-ln -s ${PWD}/tidalcontrol.py ${DST_PLAYER_FILE}
+rm -f "$DST_PLAYER_FILE"
+ln -s "${PWD}/tidalcontrol.py" "$DST_PLAYER_FILE"
+
+sed -i '/^from ac2\.players\.vollibrespot import MYNAME as SPOTIFYNAME$/a from ac2.players.tidalcontrol import TidalControl' "$AC_CONTROL_FILE"
+
+PLACEHOLDER="$(sed -nE 's/^(.*)mpris\.register_nonmpris_player\(SPOTIFYNAME,vlrctl\)$/\1/p' "$AC_CONTROL_FILE")"
+sed -i "/mpris.register_nonmpris_player(SPOTIFYNAME,vlrctl)/a \\\n${PLACEHOLDER}# TidalControl\n${PLACEHOLDER}tdctl = \
+  TidalControl()\n${PLACEHOLDER}tdctl.start()\n${PLACEHOLDER}mpris.register_nonmpris_player(tdctl.playername,tdctl)" "$AC_CONTROL_FILE"
+
+systemctl restart audiocontrol2
 
 echo "NOTE - THIS IS STILL WORK IN PROGRESS"
-echo ""
-echo "You will need to manually setup /opt/audiocontrol2/audiocontrol2.py"
-echo ""
-echo "* PLEASE CHECK THE README FOR FURTHER INSTRUCTIONS *"

--- a/work-in-progress/audiocontrol2/install.sh
+++ b/work-in-progress/audiocontrol2/install.sh
@@ -2,6 +2,7 @@
 
 AC_CONTROL_FILE="/opt/audiocontrol2/audiocontrol2.py"
 DST_PLAYER_FILE=/opt/audiocontrol2/ac2/players/tidalcontrol.py
+AC_UNIT_FILE="/etc/systemd/system/multi-user.target.wants/audiocontrol2.service"
 
 rm -f "$DST_PLAYER_FILE"
 ln -s "${PWD}/tidalcontrol.py" "$DST_PLAYER_FILE"
@@ -12,6 +13,9 @@ PLACEHOLDER="$(sed -nE 's/^(.*)mpris\.register_nonmpris_player\(SPOTIFYNAME,vlrc
 sed -i "/mpris.register_nonmpris_player(SPOTIFYNAME,vlrctl)/a \\\n${PLACEHOLDER}# TidalControl\n${PLACEHOLDER}tdctl = \
   TidalControl()\n${PLACEHOLDER}tdctl.start()\n${PLACEHOLDER}mpris.register_nonmpris_player(tdctl.playername,tdctl)" "$AC_CONTROL_FILE"
 
+# Ensure that `audiocontrol2` is started after the TidalConnect container
+sed -i 's/^After=.*$/After=sound.target dbus.service tidal.service/' "$AC_UNIT_FILE"
+systemctl daemon-reload
 systemctl restart audiocontrol2
 
 echo "NOTE - THIS IS STILL WORK IN PROGRESS"

--- a/work-in-progress/audiocontrol2/tidalcontrol.py
+++ b/work-in-progress/audiocontrol2/tidalcontrol.py
@@ -143,7 +143,7 @@ class TidalControl(PlayerControl):
 
     def tmux_scraper(self):
         logging.info('tidalcontrol::tmux_scraper')
-        cmd='docker exec -ti tidal_connect /usr/bin/tmux capture-pane -pS -10'
+        cmd='docker exec -t tidal_connect /usr/bin/tmux capture-pane -pS -10'
         stdout = subprocess.check_output(cmd.split());
         WINDOW_SIZE=40
         WINDOW_COUNT=2


### PR DESCRIPTION
It's not required to execute the docker cmd _interactively_ this fixes the issue that the audiocontrol2 daemon must be run in foreground. I have updated the README accordingly and extended the `install.sh` to make the automatic installation easier.

Edit: I notice issues after rebooting the hifiberry. The AC2 service is now started after the tidal service, but I guess since the container it is not completely ready, it will break something in AC2. It's still necessary to "systemctl restart audiocontrol2" to make it work after the tidal container is fully ready. I was working with adding a sleep in ExecPre of the AC2 unit file, but this leads into unstable system (caused by the hifiberry watchdog service?). It seems someone has to put some more work into the TidalConnect AC2 module to make it work more stable.

Edit2: When it's required to restart the TidalConnect container an restart of the audiocontrol2 service is necessary too.