### PR TITLE
fixed addresses for libcurl3 and libssl1.0.0

### DIFF
--- a/Docker/CONFIG
+++ b/Docker/CONFIG
@@ -1,1 +1,1 @@
-/mnt/5187b1c8-01/docker/tidal-connect-docker/Docker/.env
+/home/soonhyouk/Downloads/tidal-connect-docker/Docker/.env

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -7,13 +7,13 @@ RUN apt install -y -q multiarch-support libavformat57 git libportaudio2* libflac
 RUN mkdir -p /app/ifi-tidal-release
 WORKDIR /app/ifi-tidal-release
 
-RUN curl -k -O -L http://security.debian.org/debian-security/pool/updates/main/o/openssl/libssl1.0.0_1.0.1t-1+deb8u12_armhf.deb
-RUN apt install -y ./libssl1.0.0_1.0.1t-1+deb8u12_armhf.deb
-RUN rm ./libssl1.0.0_1.0.1t-1+deb8u12_armhf.deb 
+RUN curl -k -O -L https://snapshot.debian.org/archive/debian-security/20190925T215334Z/pool/updates/main/o/openssl/libssl1.0.0_1.0.1t-1%2Bdeb8u12_armhf.deb 
+RUN apt install -y ./libssl1.0.0_1.0.1t-1%2Bdeb8u12_armhf.deb
+RUN rm ./libssl1.0.0_1.0.1t-1%2Bdeb8u12_armhf.deb 
 
-RUN curl -k -O -L http://security.debian.org/debian-security/pool/updates/main/c/curl/libcurl3_7.38.0-4+deb8u16_armhf.deb
-RUN apt install -y ./libcurl3_7.38.0-4+deb8u16_armhf.deb --allow-downgrades
-RUN rm ./libcurl3_7.38.0-4+deb8u16_armhf.deb
+RUN curl -k -O -L https://snapshot.debian.org/archive/debian-security/20190913T112238Z/pool/updates/main/c/curl/libcurl3_7.38.0-4%2Bdeb8u16_armhf.deb
+RUN apt install -y ./libcurl3_7.38.0-4%2Bdeb8u16_armhf.deb --allow-downgrades
+RUN rm ./libcurl3_7.38.0-4%2Bdeb8u16_armhf.deb
 RUN apt install -y -q tmux
 
 COPY Docker/src/bin/ bin

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,7 +1,18 @@
 FROM raspbian/stretch
 
-RUN apt-get update -y -q && apt-get upgrade -y -q
-RUN apt install -y -q multiarch-support libavformat57 git libportaudio2* libflac++6v5* libavahi-common3 libavahi-client3 alsa-utils curl build-essential portaudio19-dev
+RUN echo 'deb http://archive.raspberrypi.org/debian/ stretch main' > /etc/apt/sources.list && \
+    echo 'deb http://legacy.raspbian.org/raspbian stretch main contrib non-free rpi firmware' >> /etc/apt/sources.list && \
+    echo 'deb-src http://legacy.raspbian.org/raspbian stretch main contrib non-free rpi firmware' >> /etc/apt/sources.list
+
+# Add [trusted=yes] to disable the GPG check temporarily for snapshot repositories
+RUN sed -i 's/^deb /deb [trusted=yes] /' /etc/apt/sources.list
+RUN sed -i 's/^deb-src /deb-src [trusted=yes] /' /etc/apt/sources.list
+
+RUN apt-get -o Acquire::Check-Valid-Until=false update -y -q
+RUN apt-get upgrade -y -q --allow-unauthenticated
+
+#RUN apt-get update -y -q && apt-get upgrade -y -q --allow-unauthentcated
+RUN apt install --fix-missing --fix-broken -y -q multiarch-support git  libavformat57 libportaudio2* libflac++6v5* libavahi-common3 libavahi-client3 alsa-utils curl portaudio19-dev neovim zsh
 
 #libcurl3 -y 
 RUN mkdir -p /app/ifi-tidal-release

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM raspbian/stretch
 
 RUN apt-get update -y -q && apt-get upgrade -y -q
-RUN apt install -y -q multiarch-support libavformat57 git libportaudio2* libflac++6v5* libavahi-common3 libavahi-client3 alsa-utils curl
+RUN apt install -y -q multiarch-support libavformat57 git libportaudio2* libflac++6v5* libavahi-common3 libavahi-client3 alsa-utils curl build-essential portaudio19-dev
 
 #libcurl3 -y 
 RUN mkdir -p /app/ifi-tidal-release
@@ -22,6 +22,8 @@ COPY Docker/src/play .
 COPY Docker/src/id_certificate id_certificate
 COPY Docker/src/licenses licenses
 RUN chmod a+x bin/* 
+
+ENV PA_ALSA_PLUGHW=1
 
 COPY Docker/entrypoint.sh /
 RUN chmod a+x /entrypoint.sh

--- a/Docker/entrypoint.sh
+++ b/Docker/entrypoint.sh
@@ -6,14 +6,13 @@ echo "Starting Speaker Application in Background (TMUX)"
 echo "Starting TIDAL Connect.."
 /app/ifi-tidal-release/bin/tidal_connect_application \
    --tc-certificate-path "/app/ifi-tidal-release/id_certificate/IfiAudio_ZenStream.dat" \
-   --playback-device "${PLAYBACK_DEVICE}" \
-   -f "${FRIENDLY_NAME}" \
+   -f "HiFiBerry" \
    --codec-mpegh true \
-   --codec-mqa ${MQA_CODEC} \
-   --model-name "${MODEL_NAME}" \
+   --codec-mqa false \
+   --model-name "HiFiBerry" \
    --disable-app-security false \
    --disable-web-security false \
-   --enable-mqa-passthrough ${MQA_PASSTHROUGH} \
+   --enable-mqa-passthrough false \
    --log-level 3 \
    --enable-websocket-log "0" \
    

--- a/Docker/src/pa_devs/devices
+++ b/Docker/src/pa_devs/devices
@@ -1,6 +1,0 @@
-device#0=rockchip-spdif: - (hw:0,0)
-device#1=iFi Pro iDSD: USB Audio (hw:1,0)
-device#2=sysdefault
-device#3=default
-device#4=dmix
-Number of devices = 5

--- a/templates/docker-compose.yml.tpl
+++ b/templates/docker-compose.yml.tpl
@@ -12,6 +12,8 @@ services:
     volumes:
       - ./entrypoint.sh:/entrypoint.sh
       - /var/run/dbus:/var/run/dbus
+      - /etc/asound.conf:/etc/asound.conf
+      - /etc/alsa:/etc/alsa
     restart: always
     dns:
       - ${DOCKER_DNS}


### PR DESCRIPTION
The addresses for libcurl3 and libssl1.0.0 in the docker image were previously pointing to nonfunctioning binaries