### PR TITLE
Repair libssl and curl links

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -7,11 +7,11 @@ RUN apt install -y -q multiarch-support libavformat57 git libportaudio2* libflac
 RUN mkdir -p /app/ifi-tidal-release
 WORKDIR /app/ifi-tidal-release
 
-RUN curl -k -O -L http://security.debian.org/debian-security/pool/updates/main/o/openssl/libssl1.0.0_1.0.1t-1+deb8u12_armhf.deb
+RUN curl -k -O -L http://archive.debian.org/debian-security/pool/updates/main/o/openssl/libssl1.0.0_1.0.1t-1+deb8u12_armhf.deb
 RUN apt install -y ./libssl1.0.0_1.0.1t-1+deb8u12_armhf.deb
 RUN rm ./libssl1.0.0_1.0.1t-1+deb8u12_armhf.deb 
 
-RUN curl -k -O -L http://security.debian.org/debian-security/pool/updates/main/c/curl/libcurl3_7.38.0-4+deb8u16_armhf.deb
+RUN curl -k -O -L http://archive.debian.org/debian-security/pool/updates/main/c/curl/libcurl3_7.38.0-4+deb8u16_armhf.deb
 RUN apt install -y ./libcurl3_7.38.0-4+deb8u16_armhf.deb --allow-downgrades
 RUN rm ./libcurl3_7.38.0-4+deb8u16_armhf.deb
 RUN apt install -y -q tmux


### PR DESCRIPTION
LibSSL and curl are now in the Debian archive and no longer the main branch, this fixes the links for the script.